### PR TITLE
chore(ci): add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+# Cancel previous runs on the same ref when a new one starts.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  # Avoid spurious failures from incremental compilation in CI.
+  CARGO_INCREMENTAL: 0
+
+permissions:
+  contents: read
+
+jobs:
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --workspace --all-targets -- -D warnings
+
+  test:
+    name: test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --workspace --verbose
+      - run: cargo test --workspace --verbose
+
+  wasm:
+    name: wasm32 build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build -p musubi-wasm --target wasm32-unknown-unknown
+
+  docs:
+    name: rustdoc
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo doc --workspace --no-deps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MIT License, README (Japanese), `.gitignore`, `.editorconfig`, `rustfmt.toml`.
 - OSS contribution templates: `CONTRIBUTING`, `CODE_OF_CONDUCT`, `SECURITY`, issue & PR templates.
 - Dependabot configuration for Cargo and GitHub Actions.
+- GitHub Actions CI: rustfmt, clippy (`-D warnings`), multi-OS tests (Linux/macOS/Windows), `wasm32-unknown-unknown` build, strict rustdoc.
 
 [Unreleased]: https://github.com/masaki-09/musubi/compare/...HEAD


### PR DESCRIPTION
## 概要

GitHub Actions による CI を追加。`main` への push および PR で自動実行され、同一refの古い実行は自動キャンセル (concurrency)。

## ジョブ構成

| Job | Runner | 内容 |
|---|---|---|
| **fmt**    | ubuntu-latest                     | `cargo fmt --all -- --check` |
| **clippy** | ubuntu-latest                     | `cargo clippy --workspace --all-targets -- -D warnings` |
| **test**   | ubuntu / macos / windows (matrix) | `cargo build && cargo test --workspace` |
| **wasm**   | ubuntu-latest                     | `cargo build -p musubi-wasm --target wasm32-unknown-unknown` |
| **docs**   | ubuntu-latest                     | `cargo doc --workspace --no-deps` with `RUSTDOCFLAGS=-D warnings` |

各コンパイルジョブで `Swatinem/rust-cache@v2` を使用しビルドキャッシュ。

## 設計判断

- **`pedantic` warn + `-D warnings`**: 厳しめの clippy を全PRで強制。`#[allow(clippy::xxx)]` で正当化があれば緩和可。
- **多OSテスト**: Rustコードはプラットフォーム独立だが、CRLF差異など気付きにくいバグを早期検出するため。
- **wasm32 ビルドはCIで継続検証**: PR#5 を待たず破壊的変更を防止。
- **`permissions: contents: read`**: 最小権限。リリースワークフローを別途追加する際に拡張する。

## マージ後にやること

- main ブランチ保護を有効化:
  - PR必須・最低1レビュー（自分のPRも含む）
  - 必須ステータスチェック: fmt / clippy / test (ubuntu-latest) / wasm / docs
  - 線形履歴強制（squash mergeのみ許可）
  - force push 禁止

## ローカル

```bash
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
```

> Windowsでローカルテストするには Visual Studio Build Tools が必要です（CIランナーには標準装備）。

## チェックリスト

- [x] Conventional Commits (`chore(ci): ...`)
- [x] ローカルで `cargo fmt --check`・`cargo clippy -- -D warnings` 通過
- [x] ローカルテストはMSVCリンカ不在のためスキップ → CIで検証予定