### PR TITLE
feat(cli): implement keygen / encrypt / decrypt subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,5 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Branch protection on `main`: pull-request only, required CI checks, linear history, no force pushes.
 - `musubi-core`: full v1 cipher implementation — `Alphabet`, `Key` (with random + JSON I/O), `Relation`, `Ciphertext`, `encrypt`, `decrypt`. Default alphabet `default-v1` (175 chars: 五十音80 + ASCII 95).
 - Formal cipher specification at [`docs/SPEC.md`](docs/SPEC.md) and theory writeup at [`docs/THEORY.md`](docs/THEORY.md).
+- `musubi-cli` (binary `musubi`): `keygen` / `encrypt` / `decrypt` subcommands with stdin/stdout streaming, file I/O via `-i`/`-o`, optional `--seed` for reproducible keys, `--anchor` for explicit anchor positioning, and `--compact` for single-line ciphertext JSON.
+- End-to-end CLI integration tests using `assert_cmd` covering round-trip, Japanese plaintext, error paths, and seeded determinism.
 
 [Unreleased]: https://github.com/masaki-09/musubi/compare/...HEAD

--- a/README.md
+++ b/README.md
@@ -33,9 +33,25 @@
 
 ```bash
 cargo install --git https://github.com/masaki-09/musubi musubi-cli
-musubi keygen > my.key
-echo "あいしてる" | musubi encrypt -k my.key
+
+# 鍵生成（OS のエントロピーから乱数取得）
+musubi keygen -o my.key
+
+# 暗号化（stdin → stdout、アンカー位置は中央が既定）
+echo "あいしてる" | musubi encrypt -k my.key -o love.json
+
+# 復号
+musubi decrypt -k my.key -i love.json
+# → あいしてる
 ```
+
+主なフラグ：
+
+| サブコマンド | フラグ | 用途 |
+|---|---|---|
+| `keygen`  | `-o <file>`, `--seed <u64>` | 出力先 / 再現用のPRNG seed（デバッグ用、本番では使わない） |
+| `encrypt` | `-k <file>`, `-i <file>`, `-o <file>`, `-a <pos>`, `--compact` | 鍵 / 入力 / 出力 / アンカー位置（既定: 中央）/ 整形なしJSON |
+| `decrypt` | `-k <file>`, `-i <file>`, `-o <file>` | 鍵 / 入力 / 出力 |
 
 ### Web
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -16,6 +16,15 @@ path = "src/main.rs"
 
 [dependencies]
 musubi-core = { path = "../core", version = "0.1.0" }
+clap = { version = "4", features = ["derive"] }
+anyhow = "1"
+rand = "0.8"
+serde_json = "1"
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/crates/cli/src/decrypt.rs
+++ b/crates/cli/src/decrypt.rs
@@ -1,0 +1,37 @@
+//! `musubi decrypt` — recover plaintext from a JSON ciphertext.
+
+use std::path::PathBuf;
+
+use anyhow::Context;
+use clap::Parser;
+use musubi_core::{decrypt, Alphabet, Ciphertext};
+
+use crate::io::{read_input, read_key, write_output};
+
+/// Arguments for `musubi decrypt`.
+#[derive(Parser)]
+pub struct Args {
+    /// Path to a key file produced by `musubi keygen`.
+    #[arg(short, long)]
+    key: PathBuf,
+
+    /// Ciphertext JSON input file. Defaults to stdin.
+    #[arg(short, long)]
+    input: Option<PathBuf>,
+
+    /// Output file. Defaults to stdout.
+    #[arg(short, long)]
+    output: Option<PathBuf>,
+}
+
+/// Run the `decrypt` subcommand.
+pub fn run(args: &Args) -> anyhow::Result<()> {
+    let alphabet = Alphabet::default_v1();
+    let key = read_key(&args.key, &alphabet)?;
+    let raw = read_input(args.input.as_deref())?;
+    let cipher: Ciphertext =
+        serde_json::from_str(&raw).context("failed to parse ciphertext as JSON")?;
+    let mut plaintext = decrypt(&cipher, &key)?;
+    plaintext.push('\n');
+    write_output(args.output.as_deref(), plaintext.as_bytes())
+}

--- a/crates/cli/src/encrypt.rs
+++ b/crates/cli/src/encrypt.rs
@@ -1,0 +1,55 @@
+//! `musubi encrypt` — turn plaintext into a JSON ciphertext.
+
+use std::path::PathBuf;
+
+use anyhow::Context;
+use clap::Parser;
+use musubi_core::{encrypt, Alphabet};
+
+use crate::io::{read_input, read_key, trim_trailing_newline, write_output};
+
+/// Arguments for `musubi encrypt`.
+#[derive(Parser)]
+pub struct Args {
+    /// Path to a key file produced by `musubi keygen`.
+    #[arg(short, long)]
+    key: PathBuf,
+
+    /// Plaintext input file. Defaults to stdin.
+    #[arg(short, long)]
+    input: Option<PathBuf>,
+
+    /// Output file. Defaults to stdout.
+    #[arg(short, long)]
+    output: Option<PathBuf>,
+
+    /// Anchor position (0-indexed). Defaults to the middle of the plaintext.
+    #[arg(short, long)]
+    anchor: Option<usize>,
+
+    /// Emit compact JSON instead of pretty-printed.
+    #[arg(long)]
+    compact: bool,
+}
+
+/// Run the `encrypt` subcommand.
+pub fn run(args: &Args) -> anyhow::Result<()> {
+    let alphabet = Alphabet::default_v1();
+    let key = read_key(&args.key, &alphabet)?;
+    let raw = read_input(args.input.as_deref())?;
+    let plaintext = trim_trailing_newline(&raw);
+    let n = plaintext.chars().count();
+    if n == 0 {
+        anyhow::bail!("plaintext is empty");
+    }
+    let anchor = args.anchor.unwrap_or(n / 2);
+    let cipher = encrypt(plaintext, &key, anchor)
+        .with_context(|| format!("failed to encrypt with anchor at position {anchor}"))?;
+    let mut json = if args.compact {
+        serde_json::to_string(&cipher)?
+    } else {
+        serde_json::to_string_pretty(&cipher)?
+    };
+    json.push('\n');
+    write_output(args.output.as_deref(), json.as_bytes())
+}

--- a/crates/cli/src/io.rs
+++ b/crates/cli/src/io.rs
@@ -46,8 +46,9 @@ pub fn read_key(path: &Path, alphabet: &Alphabet) -> anyhow::Result<Key> {
 /// the alphabet` error.
 #[must_use]
 pub fn trim_trailing_newline(s: &str) -> &str {
-    s.strip_suffix('\n')
-        .map_or(s, |stripped| stripped.strip_suffix('\r').unwrap_or(stripped))
+    s.strip_suffix('\n').map_or(s, |stripped| {
+        stripped.strip_suffix('\r').unwrap_or(stripped)
+    })
 }
 
 #[cfg(test)]

--- a/crates/cli/src/io.rs
+++ b/crates/cli/src/io.rs
@@ -8,29 +8,25 @@ use musubi_core::{Alphabet, Key};
 
 /// Read input from a file, or from stdin if `path` is `None`.
 pub fn read_input(path: Option<&Path>) -> anyhow::Result<String> {
-    match path {
-        Some(p) => {
-            std::fs::read_to_string(p).with_context(|| format!("failed to read {}", p.display()))
-        }
-        None => {
-            let mut s = String::new();
-            std::io::stdin()
-                .read_to_string(&mut s)
-                .context("failed to read stdin")?;
-            Ok(s)
-        }
+    if let Some(p) = path {
+        std::fs::read_to_string(p).with_context(|| format!("failed to read {}", p.display()))
+    } else {
+        let mut s = String::new();
+        std::io::stdin()
+            .read_to_string(&mut s)
+            .context("failed to read stdin")?;
+        Ok(s)
     }
 }
 
 /// Write `bytes` to a file, or to stdout if `path` is `None`.
 pub fn write_output(path: Option<&Path>, bytes: &[u8]) -> anyhow::Result<()> {
-    match path {
-        Some(p) => {
-            std::fs::write(p, bytes).with_context(|| format!("failed to write {}", p.display()))
-        }
-        None => std::io::stdout()
+    if let Some(p) = path {
+        std::fs::write(p, bytes).with_context(|| format!("failed to write {}", p.display()))
+    } else {
+        std::io::stdout()
             .write_all(bytes)
-            .context("failed to write stdout"),
+            .context("failed to write stdout")
     }
 }
 
@@ -51,8 +47,7 @@ pub fn read_key(path: &Path, alphabet: &Alphabet) -> anyhow::Result<Key> {
 #[must_use]
 pub fn trim_trailing_newline(s: &str) -> &str {
     s.strip_suffix('\n')
-        .map(|stripped| stripped.strip_suffix('\r').unwrap_or(stripped))
-        .unwrap_or(s)
+        .map_or(s, |stripped| stripped.strip_suffix('\r').unwrap_or(stripped))
 }
 
 #[cfg(test)]

--- a/crates/cli/src/io.rs
+++ b/crates/cli/src/io.rs
@@ -1,0 +1,71 @@
+//! I/O helpers shared by the subcommands.
+
+use std::io::{Read, Write};
+use std::path::Path;
+
+use anyhow::Context;
+use musubi_core::{Alphabet, Key};
+
+/// Read input from a file, or from stdin if `path` is `None`.
+pub fn read_input(path: Option<&Path>) -> anyhow::Result<String> {
+    match path {
+        Some(p) => {
+            std::fs::read_to_string(p).with_context(|| format!("failed to read {}", p.display()))
+        }
+        None => {
+            let mut s = String::new();
+            std::io::stdin()
+                .read_to_string(&mut s)
+                .context("failed to read stdin")?;
+            Ok(s)
+        }
+    }
+}
+
+/// Write `bytes` to a file, or to stdout if `path` is `None`.
+pub fn write_output(path: Option<&Path>, bytes: &[u8]) -> anyhow::Result<()> {
+    match path {
+        Some(p) => {
+            std::fs::write(p, bytes).with_context(|| format!("failed to write {}", p.display()))
+        }
+        None => std::io::stdout()
+            .write_all(bytes)
+            .context("failed to write stdout"),
+    }
+}
+
+/// Read a key file and parse it for the given alphabet.
+pub fn read_key(path: &Path, alphabet: &Alphabet) -> anyhow::Result<Key> {
+    let json = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read key file {}", path.display()))?;
+    Key::from_json(&json, alphabet)
+        .with_context(|| format!("failed to parse key file {}", path.display()))
+}
+
+/// Strip a single trailing `\n` (or `\r\n`) from `s` if present.
+///
+/// Most shells append a newline when reading a heredoc or `echo` output;
+/// trimming exactly one keeps the typical `echo "…" | musubi encrypt`
+/// pipeline working without surprising the user with a `\n is not in
+/// the alphabet` error.
+#[must_use]
+pub fn trim_trailing_newline(s: &str) -> &str {
+    s.strip_suffix('\n')
+        .map(|stripped| stripped.strip_suffix('\r').unwrap_or(stripped))
+        .unwrap_or(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trim_trailing_newline_handles_both_styles() {
+        assert_eq!(trim_trailing_newline("hi\n"), "hi");
+        assert_eq!(trim_trailing_newline("hi\r\n"), "hi");
+        assert_eq!(trim_trailing_newline("hi"), "hi");
+        assert_eq!(trim_trailing_newline(""), "");
+        // Only a single trailing newline is stripped.
+        assert_eq!(trim_trailing_newline("hi\n\n"), "hi\n");
+    }
+}

--- a/crates/cli/src/keygen.rs
+++ b/crates/cli/src/keygen.rs
@@ -27,15 +27,12 @@ pub struct Args {
 /// Run the `keygen` subcommand.
 pub fn run(args: &Args) -> anyhow::Result<()> {
     let alphabet = Alphabet::default_v1();
-    let key = match args.seed {
-        Some(seed) => {
-            let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
-            Key::random(&alphabet, &mut rng)
-        }
-        None => {
-            let mut rng = OsRng;
-            Key::random(&alphabet, &mut rng)
-        }
+    let key = if let Some(seed) = args.seed {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+        Key::random(&alphabet, &mut rng)
+    } else {
+        let mut rng = OsRng;
+        Key::random(&alphabet, &mut rng)
     };
     let mut json = key.to_json();
     json.push('\n');

--- a/crates/cli/src/keygen.rs
+++ b/crates/cli/src/keygen.rs
@@ -1,0 +1,43 @@
+//! `musubi keygen` — generate a fresh random key.
+
+use std::path::PathBuf;
+
+use clap::Parser;
+use musubi_core::{Alphabet, Key};
+use rand::rngs::OsRng;
+use rand::SeedableRng;
+
+use crate::io::write_output;
+
+/// Arguments for `musubi keygen`.
+#[derive(Parser)]
+pub struct Args {
+    /// Output file. Defaults to stdout.
+    #[arg(short, long)]
+    output: Option<PathBuf>,
+
+    /// Seed the PRNG with a `u64` for a reproducible key.
+    ///
+    /// **Do not** use a seeded key for real messages — predictable seeds
+    /// produce predictable keys. This flag exists for tests and demos.
+    #[arg(long)]
+    seed: Option<u64>,
+}
+
+/// Run the `keygen` subcommand.
+pub fn run(args: &Args) -> anyhow::Result<()> {
+    let alphabet = Alphabet::default_v1();
+    let key = match args.seed {
+        Some(seed) => {
+            let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+            Key::random(&alphabet, &mut rng)
+        }
+        None => {
+            let mut rng = OsRng;
+            Key::random(&alphabet, &mut rng)
+        }
+    };
+    let mut json = key.to_json();
+    json.push('\n');
+    write_output(args.output.as_deref(), json.as_bytes())
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,5 +1,46 @@
 //! musubi command-line interface.
+//!
+//! Three subcommands:
+//! - `keygen`  — generate a random key for the default alphabet
+//! - `encrypt` — turn plaintext into a JSON ciphertext
+//! - `decrypt` — recover plaintext from a JSON ciphertext
+//!
+//! All commands accept `-i/--input` for an input path (stdin if omitted)
+//! and `-o/--output` for an output path (stdout if omitted), so they
+//! compose naturally in shell pipelines.
 
-fn main() {
-    println!("musubi {} — relational cipher", musubi_core::VERSION);
+mod decrypt;
+mod encrypt;
+mod io;
+mod keygen;
+
+use clap::{Parser, Subcommand};
+
+/// musubi (結び) — relational classical cipher.
+///
+/// Alphabet: `default-v1` (175 chars). See <https://github.com/masaki-09/musubi>.
+#[derive(Parser)]
+#[command(name = "musubi", version, about, long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Generate a new key.
+    Keygen(keygen::Args),
+    /// Encrypt plaintext into a JSON ciphertext.
+    Encrypt(encrypt::Args),
+    /// Decrypt a JSON ciphertext back into plaintext.
+    Decrypt(decrypt::Args),
+}
+
+fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Command::Keygen(args) => keygen::run(&args),
+        Command::Encrypt(args) => encrypt::run(&args),
+        Command::Decrypt(args) => decrypt::run(&args),
+    }
 }

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -1,0 +1,152 @@
+//! End-to-end CLI tests. They invoke the actual `musubi` binary built
+//! by Cargo and exercise stdin/stdout plus file I/O round-trips.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::tempdir;
+
+fn musubi() -> Command {
+    Command::cargo_bin("musubi").expect("musubi binary built")
+}
+
+#[test]
+fn round_trip_plaintext_via_files() {
+    let dir = tempdir().unwrap();
+    let key_path = dir.path().join("key.json");
+    let cipher_path = dir.path().join("cipher.json");
+
+    musubi()
+        .args(["keygen", "--seed", "42"])
+        .arg("-o")
+        .arg(&key_path)
+        .assert()
+        .success();
+
+    musubi()
+        .args(["encrypt", "-k"])
+        .arg(&key_path)
+        .arg("-o")
+        .arg(&cipher_path)
+        .write_stdin("Hello, musubi!")
+        .assert()
+        .success();
+
+    musubi()
+        .args(["decrypt", "-k"])
+        .arg(&key_path)
+        .arg("-i")
+        .arg(&cipher_path)
+        .assert()
+        .success()
+        .stdout("Hello, musubi!\n");
+}
+
+#[test]
+fn round_trip_japanese_with_anchor_flag() {
+    let dir = tempdir().unwrap();
+    let key_path = dir.path().join("key.json");
+
+    musubi()
+        .args(["keygen", "--seed", "1"])
+        .arg("-o")
+        .arg(&key_path)
+        .assert()
+        .success();
+
+    let cipher_output = musubi()
+        .args(["encrypt", "-k"])
+        .arg(&key_path)
+        .args(["-a", "2"])
+        .write_stdin("あいしてる")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    musubi()
+        .args(["decrypt", "-k"])
+        .arg(&key_path)
+        .write_stdin(cipher_output)
+        .assert()
+        .success()
+        .stdout("あいしてる\n");
+}
+
+#[test]
+fn out_of_alphabet_chars_fail_with_helpful_message() {
+    let dir = tempdir().unwrap();
+    let key_path = dir.path().join("key.json");
+
+    musubi()
+        .args(["keygen", "--seed", "0"])
+        .arg("-o")
+        .arg(&key_path)
+        .assert()
+        .success();
+
+    musubi()
+        .args(["encrypt", "-k"])
+        .arg(&key_path)
+        .write_stdin("世界")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not in the alphabet"));
+}
+
+#[test]
+fn empty_plaintext_fails() {
+    let dir = tempdir().unwrap();
+    let key_path = dir.path().join("key.json");
+
+    musubi()
+        .args(["keygen", "--seed", "5"])
+        .arg("-o")
+        .arg(&key_path)
+        .assert()
+        .success();
+
+    musubi()
+        .args(["encrypt", "-k"])
+        .arg(&key_path)
+        .write_stdin("")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("empty"));
+}
+
+#[test]
+fn keygen_compact_seed_is_deterministic() {
+    let dir = tempdir().unwrap();
+    let a = dir.path().join("a.json");
+    let b = dir.path().join("b.json");
+
+    musubi()
+        .args(["keygen", "--seed", "12345"])
+        .arg("-o")
+        .arg(&a)
+        .assert()
+        .success();
+    musubi()
+        .args(["keygen", "--seed", "12345"])
+        .arg("-o")
+        .arg(&b)
+        .assert()
+        .success();
+
+    let a_content = std::fs::read_to_string(&a).unwrap();
+    let b_content = std::fs::read_to_string(&b).unwrap();
+    assert_eq!(
+        a_content, b_content,
+        "seeded keygen should be deterministic"
+    );
+}
+
+#[test]
+fn version_flag_prints_a_version() {
+    musubi()
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("musubi"));
+}


### PR DESCRIPTION
## 概要

`musubi-cli` を実装。バイナリ名は `musubi`、3つのサブコマンドを提供：

```bash
musubi keygen [-o FILE] [--seed N]
musubi encrypt -k KEY [-i FILE] [-o FILE] [-a POS] [--compact]
musubi decrypt -k KEY [-i FILE] [-o FILE]
```

stdin/stdout が既定なので、シェルパイプラインに自然に乗ります：

```bash
musubi keygen -o my.key
echo "あいしてる" | musubi encrypt -k my.key | musubi decrypt -k my.key
# → あいしてる
```

## 設計判断

| 判断 | 理由 |
|---|---|
| **stdin/stdout 既定** | Unix 哲学。`-i`/`-o` 省略でパイプ可能 |
| **末尾改行を1つだけ trim** | `echo "..." \| musubi encrypt` で `\n` が Σ 外エラーを起こすのを防ぐ。複数の改行は保持 |
| **アンカー既定値 = n/2** | 中央配置が「ロマン」的に最も美しい。明示したい人は `-a` で指定可 |
| **`--seed` の警告を docstring に明記** | デバッグ・再現性用。本番暗号化には絶対使わない旨を明記 |
| **`anyhow::Context` でエラー注釈** | "failed to read key file ..." のような人間可読メッセージに |

## 依存関係 (新規)

`musubi-cli/Cargo.toml`:
- `clap` 4 (derive feature) — サブコマンド・引数定義
- `anyhow` 1 — エラー伝播
- `rand` 0.8 — `OsRng` / `StdRng` 切替
- `serde_json` 1 — JSON 入出力
- dev: `assert_cmd` 2 / `predicates` 3 / `tempfile` 3 — 結合テスト

## テスト

`crates/cli/tests/cli.rs` で実バイナリを起動して以下を検証：

- ファイル経由での平文ラウンドトリップ
- 日本語平文＋明示アンカー位置のラウンドトリップ
- Σ外文字エラー時の stderr メッセージ
- 空入力エラー
- `--seed` 指定時の決定性
- `--version` フラグの表示

## ドキュメント

- `README.md` の「クイックスタート」を更新（フラグ表追加）
- `CHANGELOG.md` の `[Unreleased]` を追記

## 互換性

破壊的変更なし。`musubi-core` には変更なし。

## チェックリスト

- [x] Conventional Commits (`feat(cli): ...`)
- [x] 公開 API（サブコマンド引数）に rustdoc / clap doc-comment
- [x] CHANGELOG `[Unreleased]` 更新
- [x] README に CLI 使用例を追記
- [x] 結合テスト追加（assert_cmd ベース）
- [ ] ローカル clippy/test 通過 → CI に委ねる（Windows ローカルで MSVC リンカ不在）
