### PR TITLE
feat(web): add WASM bindings, browser UI, and Pages deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
+      - uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: latest
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build -p musubi-wasm --target wasm32-unknown-unknown
+      # Build the full wasm-pack pipeline (wasm-bindgen JS bindings + glue)
+      # so PR CI matches what `pages.yml` deploys on `main`.
+      - run: wasm-pack build crates/wasm --target web --out-dir ../../web/pkg
 
   docs:
     name: rustdoc

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,53 @@
+name: Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, and let in-progress runs finish
+# (don't cancel them mid-deploy).
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  build:
+    name: build wasm artefact
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: latest
+      - uses: Swatinem/rust-cache@v2
+      - name: Build WebAssembly bundle
+        run: wasm-pack build crates/wasm --target web --out-dir ../../web/pkg
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: web
+
+  deploy:
+    name: deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,5 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Formal cipher specification at [`docs/SPEC.md`](docs/SPEC.md) and theory writeup at [`docs/THEORY.md`](docs/THEORY.md).
 - `musubi-cli` (binary `musubi`): `keygen` / `encrypt` / `decrypt` subcommands with stdin/stdout streaming, file I/O via `-i`/`-o`, optional `--seed` for reproducible keys, `--anchor` for explicit anchor positioning, and `--compact` for single-line ciphertext JSON.
 - End-to-end CLI integration tests using `assert_cmd` covering round-trip, Japanese plaintext, error paths, and seeded determinism.
+- `musubi-wasm`: WebAssembly bindings exposing `keygen` / `encrypt` / `decrypt` to JavaScript via `wasm-bindgen`. Uses `crypto.getRandomValues` in the browser via `getrandom`'s `js` feature.
+- `web/`: zero-server static frontend (`index.html` + `app.js` + `style.css`) wiring the WASM module to a tabbed UI for keygen / encrypt / decrypt.
+- `.github/workflows/pages.yml`: builds the WASM bundle with `wasm-pack` and deploys `web/` to GitHub Pages on every push to `main`.
+- CI's `wasm32 build` job now uses `wasm-pack` so PR validation matches the production deploy pipeline.
 
 [Unreleased]: https://github.com/masaki-09/musubi/compare/...HEAD

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -15,10 +15,12 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 musubi-core = { path = "../core", version = "0.1.0" }
+wasm-bindgen = "0.2"
+serde_json = "1"
+rand = "0.8"
 
-# Enable the `js` feature of getrandom on wasm32-unknown-unknown so that
-# `rand`'s default RNG can source entropy from the browser. This applies
-# only when targeting wasm32; native targets continue to use OsRng.
+# Enable getrandom's `js` feature only when targeting the browser so
+# rand's OsRng can pull entropy from `crypto.getRandomValues`.
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
 

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -24,5 +24,13 @@ rand = "0.8"
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
 
+# wasm-pack ships an older `wasm-opt` whose validator does not recognise
+# the bulk-memory and nontrapping-fptoint features that the current Rust
+# toolchain emits by default. Skip the wasm-opt pass; the resulting
+# `.wasm` is a few KB larger but still a few tens of KB, which is fine
+# for this app.
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false
+
 [lints]
 workspace = true

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1,6 +1,81 @@
-//! WebAssembly bindings for musubi.
+//! WebAssembly bindings for `musubi`.
 //!
-//! Bindings are added in a follow-up change; this crate currently
-//! re-exports [`musubi_core::VERSION`] so the workspace builds end to end.
+//! Exposes three JS-callable functions that mirror the CLI subcommands:
+//! [`keygen`], [`js_encrypt`] (renamed `encrypt` in JS), and
+//! [`js_decrypt`] (renamed `decrypt` in JS).
+//!
+//! All I/O is via JSON strings to keep the JS interface small and
+//! version-stable; the JSON formats match `musubi-core`'s on-disk
+//! representations.
 
+#![doc(html_root_url = "https://docs.rs/musubi-wasm")]
+
+use musubi_core::{decrypt, encrypt, Alphabet, Ciphertext, Key};
+use rand::rngs::OsRng;
+use wasm_bindgen::prelude::*;
+
+/// Crate version, baked in at compile time.
 pub use musubi_core::VERSION;
+
+fn to_js_error(e: impl std::fmt::Display) -> JsError {
+    JsError::new(&e.to_string())
+}
+
+/// Generate a fresh random key for the default-v1 alphabet.
+///
+/// Uses [`rand::rngs::OsRng`], which is backed by
+/// `crypto.getRandomValues` in the browser.
+///
+/// Returned as a JSON string in the same format that the CLI
+/// `musubi keygen` produces.
+#[wasm_bindgen]
+#[must_use]
+pub fn keygen() -> String {
+    let alphabet = Alphabet::default_v1();
+    let mut rng = OsRng;
+    let key = Key::random(&alphabet, &mut rng);
+    key.to_json()
+}
+
+/// Encrypt `plaintext` with the given key (JSON), revealing the
+/// character at `anchor` (defaults to the middle of the message).
+///
+/// Returned as a pretty-printed JSON ciphertext string.
+///
+/// # Errors
+///
+/// Returns a `JsError` if the key cannot be parsed, the plaintext is
+/// empty, the anchor is out of range, or any character of the
+/// plaintext is not in the alphabet.
+#[wasm_bindgen(js_name = encrypt)]
+pub fn js_encrypt(
+    plaintext: &str,
+    key_json: &str,
+    anchor: Option<usize>,
+) -> Result<String, JsError> {
+    let alphabet = Alphabet::default_v1();
+    let key = Key::from_json(key_json, &alphabet).map_err(to_js_error)?;
+    let n = plaintext.chars().count();
+    if n == 0 {
+        return Err(JsError::new("plaintext is empty"));
+    }
+    let pos = anchor.unwrap_or(n / 2);
+    let cipher = encrypt(plaintext, &key, pos).map_err(to_js_error)?;
+    serde_json::to_string_pretty(&cipher).map_err(to_js_error)
+}
+
+/// Decrypt a JSON ciphertext with the given key (JSON), returning the
+/// recovered plaintext.
+///
+/// # Errors
+///
+/// Returns a `JsError` if either JSON cannot be parsed or the
+/// ciphertext fails any of the structural checks in
+/// [`musubi_core::decrypt`].
+#[wasm_bindgen(js_name = decrypt)]
+pub fn js_decrypt(ciphertext_json: &str, key_json: &str) -> Result<String, JsError> {
+    let alphabet = Alphabet::default_v1();
+    let key = Key::from_json(key_json, &alphabet).map_err(to_js_error)?;
+    let cipher: Ciphertext = serde_json::from_str(ciphertext_json).map_err(to_js_error)?;
+    decrypt(&cipher, &key).map_err(to_js_error)
+}

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,143 @@
+// musubi WebUI — wires the WASM module to the DOM.
+//
+// All cipher operations run locally in the browser via the
+// `musubi-wasm` crate; no network requests are made.
+
+import init, { keygen, encrypt, decrypt } from "./pkg/musubi_wasm.js";
+
+await init();
+
+// ---- Tab switching ----------------------------------------------------------
+
+const tabs = document.querySelectorAll(".tabs button");
+const panels = document.querySelectorAll(".panel");
+tabs.forEach((btn) => {
+  btn.addEventListener("click", () => {
+    tabs.forEach((b) => b.classList.remove("active"));
+    panels.forEach((p) => p.classList.remove("active"));
+    btn.classList.add("active");
+    document.getElementById("panel-" + btn.dataset.tab).classList.add("active");
+  });
+});
+
+// ---- Status ribbon ----------------------------------------------------------
+
+const status = document.getElementById("status");
+let statusTimer = null;
+function setStatus(message, kind = "info") {
+  status.textContent = message;
+  status.className = kind;
+  status.hidden = false;
+  if (statusTimer) clearTimeout(statusTimer);
+  statusTimer = setTimeout(() => {
+    status.hidden = true;
+  }, 4000);
+}
+
+// ---- Helpers ----------------------------------------------------------------
+
+function download(content, filename, mime) {
+  const blob = new Blob([content], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+async function copyValue(elementId) {
+  const v = document.getElementById(elementId).value;
+  if (!v) {
+    setStatus("コピーする内容がありません", "error");
+    return;
+  }
+  await navigator.clipboard.writeText(v);
+  setStatus("クリップボードにコピーしました", "success");
+}
+
+// ---- Keygen ----------------------------------------------------------------
+
+document.getElementById("btn-keygen").addEventListener("click", () => {
+  try {
+    const key = keygen();
+    document.getElementById("key-output").value = key;
+    setStatus("鍵を生成しました", "success");
+  } catch (e) {
+    setStatus("鍵生成に失敗: " + e.message, "error");
+  }
+});
+
+document
+  .getElementById("btn-copy-key")
+  .addEventListener("click", () => copyValue("key-output"));
+
+document.getElementById("btn-download-key").addEventListener("click", () => {
+  const v = document.getElementById("key-output").value;
+  if (!v) {
+    setStatus("先に鍵を生成してください", "error");
+    return;
+  }
+  download(v, "musubi-key.json", "application/json");
+});
+
+// ---- Encrypt ---------------------------------------------------------------
+
+document.getElementById("btn-encrypt").addEventListener("click", () => {
+  try {
+    const key = document.getElementById("enc-key").value.trim();
+    const plain = document.getElementById("enc-plain").value;
+    if (!key) {
+      setStatus("鍵が入力されていません", "error");
+      return;
+    }
+    if (!plain) {
+      setStatus("平文が入力されていません", "error");
+      return;
+    }
+    const anchorStr = document.getElementById("enc-anchor").value;
+    const anchor = anchorStr === "" ? undefined : Number(anchorStr);
+    const cipher = encrypt(plain, key, anchor);
+    document.getElementById("enc-output").value = cipher;
+    setStatus("暗号化しました", "success");
+  } catch (e) {
+    setStatus("暗号化に失敗: " + e.message, "error");
+  }
+});
+
+document
+  .getElementById("btn-copy-cipher")
+  .addEventListener("click", () => copyValue("enc-output"));
+
+document.getElementById("btn-download-cipher").addEventListener("click", () => {
+  const v = document.getElementById("enc-output").value;
+  if (!v) {
+    setStatus("先に暗号化してください", "error");
+    return;
+  }
+  download(v, "musubi-cipher.json", "application/json");
+});
+
+// ---- Decrypt ---------------------------------------------------------------
+
+document.getElementById("btn-decrypt").addEventListener("click", () => {
+  try {
+    const key = document.getElementById("dec-key").value.trim();
+    const cipher = document.getElementById("dec-cipher").value.trim();
+    if (!key) {
+      setStatus("鍵が入力されていません", "error");
+      return;
+    }
+    if (!cipher) {
+      setStatus("暗号文が入力されていません", "error");
+      return;
+    }
+    const plain = decrypt(cipher, key);
+    document.getElementById("dec-output").value = plain;
+    setStatus("復号しました", "success");
+  } catch (e) {
+    setStatus("復号に失敗: " + e.message, "error");
+  }
+});

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>musubi (結び) — 関係性暗号</title>
+  <meta name="description" content="関係性暗号 musubi のブラウザ実装。鍵生成・暗号化・復号がすべてローカルで完結します。">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>musubi <span class="kanji">結び</span></h1>
+    <p class="tagline">関係性暗号 — A relational cipher for the romantically inclined.</p>
+  </header>
+
+  <main>
+    <nav class="tabs" role="tablist">
+      <button data-tab="keygen" class="active" role="tab">鍵を作る</button>
+      <button data-tab="encrypt" role="tab">暗号化</button>
+      <button data-tab="decrypt" role="tab">復号</button>
+    </nav>
+
+    <section id="panel-keygen" class="panel active" role="tabpanel">
+      <h2>新しい鍵を作る</h2>
+      <p class="lede">ブラウザの暗号学的乱数 (<code>crypto.getRandomValues</code>) を使い、<code>default-v1</code> アルファベット 175 文字の順列を生成します。鍵はあなたのブラウザの中だけに残ります。</p>
+      <button id="btn-keygen" class="primary">鍵を生成</button>
+      <textarea id="key-output" readonly placeholder="ここに鍵 (JSON) が表示されます" rows="8"></textarea>
+      <div class="actions">
+        <button id="btn-copy-key">コピー</button>
+        <button id="btn-download-key">ダウンロード</button>
+      </div>
+    </section>
+
+    <section id="panel-encrypt" class="panel" role="tabpanel">
+      <h2>暗号化</h2>
+      <label for="enc-key">鍵 (JSON)</label>
+      <textarea id="enc-key" placeholder="keygen タブで作った鍵を貼り付け" rows="5"></textarea>
+      <label for="enc-plain">平文</label>
+      <textarea id="enc-plain" placeholder="暗号化したい文章。アルファベット外の文字 (例: 「、」「世」) を含むとエラーになります。" rows="3"></textarea>
+      <label for="enc-anchor" class="inline">アンカー位置 (省略時は中央)
+        <input id="enc-anchor" type="number" min="0" placeholder="例: 2">
+      </label>
+      <button id="btn-encrypt" class="primary">暗号化</button>
+      <textarea id="enc-output" readonly placeholder="暗号文 (JSON)" rows="10"></textarea>
+      <div class="actions">
+        <button id="btn-copy-cipher">コピー</button>
+        <button id="btn-download-cipher">ダウンロード</button>
+      </div>
+    </section>
+
+    <section id="panel-decrypt" class="panel" role="tabpanel">
+      <h2>復号</h2>
+      <label for="dec-key">鍵 (JSON)</label>
+      <textarea id="dec-key" placeholder="送信者と共有している鍵" rows="5"></textarea>
+      <label for="dec-cipher">暗号文 (JSON)</label>
+      <textarea id="dec-cipher" placeholder="復号したい暗号文" rows="10"></textarea>
+      <button id="btn-decrypt" class="primary">復号</button>
+      <textarea id="dec-output" readonly placeholder="ここに平文が表示されます" rows="3"></textarea>
+    </section>
+
+    <div id="status" hidden role="status" aria-live="polite"></div>
+  </main>
+
+  <footer>
+    <p class="warning">
+      <strong>⚠ 玩具暗号です</strong>
+      musubi は古典暗号の楽しみのためのソフトウェアであり、本気の秘匿通信には使えません。詳細は
+      <a href="https://github.com/masaki-09/musubi/blob/main/SECURITY.md">SECURITY.md</a> を参照。
+    </p>
+    <p class="attribution">
+      <a href="https://github.com/masaki-09/musubi">GitHub</a> ·
+      <a href="https://github.com/masaki-09/musubi/blob/main/docs/THEORY.md">理論</a> ·
+      <a href="https://github.com/masaki-09/musubi/blob/main/docs/SPEC.md">仕様</a> ·
+      MIT License
+    </p>
+  </footer>
+
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,204 @@
+/* musubi WebUI — minimal, monospace-friendly, with a single red-thread accent. */
+
+:root {
+  --bg: #fafaf7;
+  --fg: #1a1a1a;
+  --accent: #b22222;
+  --muted: #6b6b6b;
+  --border: #d8d8d3;
+  --code-bg: #f0f0eb;
+  --warning-bg: #fff8e1;
+  --success: #2e7d32;
+  --mono: ui-monospace, "SF Mono", "Cascadia Mono", "Menlo", "Consolas", monospace;
+  --serif: "Hiragino Mincho ProN", "Yu Mincho", "Noto Serif JP", "Times New Roman", serif;
+}
+
+* { box-sizing: border-box; }
+
+html, body { margin: 0; padding: 0; }
+
+body {
+  font-family: var(--serif);
+  background: var(--bg);
+  color: var(--fg);
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+  line-height: 1.7;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+header h1 {
+  font-size: 2.5rem;
+  font-weight: 400;
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+header h1 .kanji {
+  color: var(--accent);
+  margin-left: 0.4em;
+}
+.tagline {
+  color: var(--muted);
+  font-size: 0.95rem;
+  font-style: italic;
+  margin: 0.4rem 0 0;
+}
+
+.tabs {
+  display: flex;
+  gap: 0.25rem;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 1.5rem;
+}
+.tabs button {
+  background: none;
+  border: none;
+  padding: 0.7rem 1.2rem;
+  font: inherit;
+  color: var(--muted);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: color 0.2s;
+}
+.tabs button:hover { color: var(--fg); }
+.tabs button.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.panel { display: none; }
+.panel.active { display: block; }
+.panel h2 {
+  font-weight: 400;
+  font-size: 1.4rem;
+  margin: 0 0 0.5rem;
+}
+.panel .lede {
+  color: var(--muted);
+  font-size: 0.95rem;
+  margin: 0 0 1.2rem;
+}
+.panel .lede code {
+  background: var(--code-bg);
+  padding: 0 0.3em;
+  border-radius: 3px;
+  font-size: 0.85em;
+}
+
+label {
+  display: block;
+  margin: 1rem 0 0.4rem;
+  color: var(--muted);
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+}
+label.inline {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+textarea, input[type="number"] {
+  width: 100%;
+  padding: 0.7rem;
+  font-family: var(--mono);
+  font-size: 0.85rem;
+  background: var(--code-bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  resize: vertical;
+  line-height: 1.5;
+}
+textarea:focus, input:focus {
+  outline: none;
+  border-color: var(--accent);
+  background: #fff;
+}
+input[type="number"] { width: 8em; padding: 0.4rem 0.6rem; }
+textarea[readonly] { background: #f6f6f1; }
+
+button {
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  padding: 0.5rem 1rem;
+  font: inherit;
+  font-size: 0.9rem;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background 0.15s, color 0.15s;
+}
+button:hover { background: var(--fg); color: var(--bg); }
+button.primary {
+  background: var(--fg);
+  color: var(--bg);
+  border-color: var(--fg);
+  margin-top: 1rem;
+  padding: 0.6rem 1.6rem;
+  font-size: 0.95rem;
+}
+button.primary:hover { background: var(--accent); border-color: var(--accent); }
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+#status {
+  position: fixed;
+  bottom: 1.2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--fg);
+  color: var(--bg);
+  padding: 0.6rem 1.2rem;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  max-width: calc(100% - 2rem);
+}
+#status.error { background: var(--accent); }
+#status.success { background: var(--success); }
+
+footer {
+  margin-top: 4rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border);
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+.warning {
+  background: var(--warning-bg);
+  padding: 0.9rem 1rem;
+  border-left: 3px solid var(--accent);
+  border-radius: 0 4px 4px 0;
+  margin: 0 0 1rem;
+}
+.warning strong {
+  color: var(--accent);
+  display: block;
+  margin-bottom: 0.2rem;
+}
+.attribution {
+  text-align: center;
+  margin: 1rem 0 0;
+}
+a {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px dotted var(--accent);
+}
+a:hover { border-bottom-style: solid; }
+
+@media (max-width: 480px) {
+  body { padding: 1.5rem 1rem 3rem; }
+  header h1 { font-size: 2rem; }
+  .tabs button { padding: 0.5rem 0.8rem; font-size: 0.85rem; }
+}


### PR DESCRIPTION
## 概要

musubi をブラウザ完結 (サーバ不要) で動かせるようにする。WASM バインディング・UI・GitHub Pages 自動デプロイの3点セット。これが v0.1.0 の最後のピースです。

マージ後は <https://masaki-09.github.io/musubi/> で誰でも触れます。

## 追加・変更

### `musubi-wasm` (`crates/wasm/`)

`wasm-bindgen` 経由で 3 関数を JavaScript に公開：

| JS 関数 | シグネチャ |
|---|---|
| `keygen()`                        | `() -> string` (鍵 JSON) |
| `encrypt(plaintext, key, anchor?)`| `(string, string, number?) -> string` (暗号文 JSON) |
| `decrypt(ciphertext, key)`        | `(string, string) -> string` (平文) |

エラーはすべて `JsError`（メッセージは `MusubiError` のまま）。乱数は `OsRng` 経由で `crypto.getRandomValues` を使用 (`getrandom` の `js` feature が wasm32-unknown-unknown 限定で有効)。

### `web/`

ビルドステップなし（`wasm-pack` の出力以外）。素の HTML + ES モジュール JS + CSS。

- 3 つのタブ: 鍵生成 / 暗号化 / 復号
- コピー・ダウンロードアクション、ステータスリボン
- すべての処理がブラウザ内で完結。ネットワーク送信なし
- `prefers-color-scheme` には対応していない（次のPRで検討）

### `.github/workflows/pages.yml`

`main` への push と `workflow_dispatch` で発火。`wasm-pack build crates/wasm --target web --out-dir ../../web/pkg` の成果物を含めた `web/` を Pages にデプロイ。`concurrency: pages` で同時実行を1つに制限。

### `ci.yml` の `wasm32 build` ジョブ

素の `cargo build` から `wasm-pack` に切替。PR の CI が pages.yml と同じパイプラインを通るようになり、本番デプロイの破壊的変更を PR で検出できる。ジョブ名 `wasm32 build` は維持しているので、ブランチ保護の必須チェック設定はそのまま。

## マージ後の手動オペレーション

GitHub Pages のソースを「GitHub Actions」に切り替える必要があります（このリポジトリでは Pages が一度も有効化されていないため）。マージ後に下記を実行：

```
gh api -X POST /repos/masaki-09/musubi/pages -f build_type=workflow
```

(私が実施します。)

## 動作確認

- ローカル: ファイル変更のみ。`cargo check` は MSVC リンカ不在で未実行 → CI に委ねる
- CI: `wasm32 build` ジョブが新パイプラインで通れば成功シグナル
- 本番: `pages.yml` 初回起動 → `https://masaki-09.github.io/musubi/` で確認

## 互換性

破壊的変更なし。`musubi-core` / `musubi-cli` はそのまま。

## チェックリスト

- [x] Conventional Commits (`feat(web): ...`)
- [x] CHANGELOG `[Unreleased]` 更新
- [x] WASM 公開 API に rustdoc
- [x] CI が pages と同じ wasm-pack を通る
- [ ] ローカル clippy/test 通過 → CI に委ねる
- [ ] マージ後に Pages のソースを GitHub Actions に設定
