### PR TITLE
feat(cli): --strategy / --noise / --seed flags for encrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ musubi keygen -o my.key
 # 暗号化（stdin → stdout、アンカー位置は中央が既定）
 echo "あいしてる" | musubi encrypt -k my.key -o love.json
 
+# 多重結び（chain encoder）— 関係グラフがランダム木に
+echo "あいしてる" | musubi encrypt -k my.key --strategy chain
+
+# 迷い糸（noise injection）— 平文長すら隠す
+echo "あいしてる" | musubi encrypt -k my.key --noise 5
+
 # 復号
 musubi decrypt -k my.key -i love.json
 # → あいしてる
@@ -55,7 +61,8 @@ musubi decrypt -k my.key -i love.json
 |---|---|---|
 | `keygen`  | `-o <file>`, `--seed <u64>` | 出力先 / 再現用のPRNG seed（デバッグ用、本番では使わない） |
 | `encrypt` | `-k <file>`, `-i <file>`, `-o <file>`, `-a <pos>`, `--compact` | 鍵 / 入力 / 出力 / アンカー位置（既定: 中央）/ 整形なしJSON |
-| `decrypt` | `-k <file>`, `-i <file>`, `-o <file>` | 鍵 / 入力 / 出力 |
+| `encrypt` | `--strategy <canonical\|chain>`, `--noise <N>`, `--seed <u64>` | エンコーダ戦略 / 迷い糸の本数 / 乱数シード（v0.2〜） |
+| `decrypt` | `-k <file>`, `-i <file>`, `-o <file>` | 鍵 / 入力 / 出力（迷い糸入りも自動判別） |
 
 ### Web
 

--- a/crates/cli/src/encrypt.rs
+++ b/crates/cli/src/encrypt.rs
@@ -3,10 +3,23 @@
 use std::path::PathBuf;
 
 use anyhow::Context;
-use clap::Parser;
-use musubi_core::{encrypt, Alphabet};
+use clap::{Parser, ValueEnum};
+use musubi_core::{encrypt, encrypt_woven, Alphabet, Ciphertext};
+use rand::rngs::OsRng;
+use rand::SeedableRng;
 
 use crate::io::{read_input, read_key, trim_trailing_newline, write_output};
+
+/// Encoder strategy selectable on the command line.
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum Strategy {
+    /// v0.1 canonical encoder — every relation references the immediately
+    /// adjacent position toward the anchor. Deterministic, no RNG used.
+    Canonical,
+    /// v0.2 chain encoder (多重結び) — relations form a uniformly random
+    /// spanning tree rooted at the anchor. Required when `--noise > 0`.
+    Chain,
+}
 
 /// Arguments for `musubi encrypt`.
 #[derive(Parser)]
@@ -30,6 +43,23 @@ pub struct Args {
     /// Emit compact JSON instead of pretty-printed.
     #[arg(long)]
     compact: bool,
+
+    /// Encoder strategy. `canonical` (default) preserves v0.1 output;
+    /// `chain` produces a random spanning tree (and is required for noise).
+    #[arg(long, value_enum, default_value_t = Strategy::Canonical)]
+    strategy: Strategy,
+
+    /// Inject `noise` dummy characters (迷い糸). Hides the true plaintext
+    /// length and structure. Implies `--strategy chain`.
+    #[arg(long, default_value_t = 0)]
+    noise: usize,
+
+    /// Seed the chain/noise RNG with a `u64` for reproducible output.
+    /// Ignored under `--strategy canonical` with `--noise 0`.
+    ///
+    /// **Do not** use a seeded RNG for real messages.
+    #[arg(long)]
+    seed: Option<u64>,
 }
 
 /// Run the `encrypt` subcommand.
@@ -43,8 +73,23 @@ pub fn run(args: &Args) -> anyhow::Result<()> {
         anyhow::bail!("plaintext is empty");
     }
     let anchor = args.anchor.unwrap_or(n / 2);
-    let cipher = encrypt(plaintext, &key, anchor)
-        .with_context(|| format!("failed to encrypt with anchor at position {anchor}"))?;
+
+    let needs_chain = matches!(args.strategy, Strategy::Chain) || args.noise > 0;
+
+    let cipher: Ciphertext = if needs_chain {
+        if let Some(seed) = args.seed {
+            let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+            encrypt_woven(plaintext, &key, anchor, args.noise, &mut rng)
+        } else {
+            let mut rng = OsRng;
+            encrypt_woven(plaintext, &key, anchor, args.noise, &mut rng)
+        }
+        .with_context(|| format!("failed to encrypt with anchor at position {anchor}"))?
+    } else {
+        encrypt(plaintext, &key, anchor)
+            .with_context(|| format!("failed to encrypt with anchor at position {anchor}"))?
+    };
+
     let mut json = if args.compact {
         serde_json::to_string(&cipher)?
     } else {

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -143,6 +143,112 @@ fn keygen_compact_seed_is_deterministic() {
 }
 
 #[test]
+fn round_trip_with_chain_strategy() {
+    let dir = tempdir().unwrap();
+    let key_path = dir.path().join("key.json");
+
+    musubi()
+        .args(["keygen", "--seed", "100"])
+        .arg("-o")
+        .arg(&key_path)
+        .assert()
+        .success();
+
+    let cipher_output = musubi()
+        .args(["encrypt", "-k"])
+        .arg(&key_path)
+        .args(["--strategy", "chain", "--seed", "7"])
+        .write_stdin("あいしてる")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    musubi()
+        .args(["decrypt", "-k"])
+        .arg(&key_path)
+        .write_stdin(cipher_output)
+        .assert()
+        .success()
+        .stdout("あいしてる\n");
+}
+
+#[test]
+fn round_trip_with_noise_injection() {
+    let dir = tempdir().unwrap();
+    let key_path = dir.path().join("key.json");
+
+    musubi()
+        .args(["keygen", "--seed", "200"])
+        .arg("-o")
+        .arg(&key_path)
+        .assert()
+        .success();
+
+    let cipher_output = musubi()
+        .args(["encrypt", "-k"])
+        .arg(&key_path)
+        .args(["--noise", "5", "--seed", "13"])
+        .write_stdin("あいしてる")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    // Ciphertext must contain plaintext_indices marker for noise mode.
+    let cipher_str = std::str::from_utf8(&cipher_output).unwrap();
+    assert!(
+        cipher_str.contains("plaintext_indices"),
+        "noise mode should emit ext.plaintext_indices: {cipher_str}"
+    );
+
+    musubi()
+        .args(["decrypt", "-k"])
+        .arg(&key_path)
+        .write_stdin(cipher_output)
+        .assert()
+        .success()
+        .stdout("あいしてる\n");
+}
+
+#[test]
+fn seeded_chain_encrypt_is_deterministic() {
+    let dir = tempdir().unwrap();
+    let key_path = dir.path().join("key.json");
+
+    musubi()
+        .args(["keygen", "--seed", "300"])
+        .arg("-o")
+        .arg(&key_path)
+        .assert()
+        .success();
+
+    let a = musubi()
+        .args(["encrypt", "-k"])
+        .arg(&key_path)
+        .args(["--strategy", "chain", "--seed", "555"])
+        .write_stdin("musubi")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let b = musubi()
+        .args(["encrypt", "-k"])
+        .arg(&key_path)
+        .args(["--strategy", "chain", "--seed", "555"])
+        .write_stdin("musubi")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert_eq!(a, b, "seeded chain encrypt should be deterministic");
+}
+
+#[test]
 fn version_flag_prints_a_version() {
     musubi()
         .arg("--version")


### PR DESCRIPTION
## Summary

PR #C of the [v0.2 ロードマップ](docs/PROPOSAL-v0.2.md). Surfaces the new core encoders on the CLI.

### New `musubi encrypt` flags

| Flag | Values | Default |
|---|---|---|
| `--strategy` | `canonical` / `chain` | `canonical` |
| `--noise <N>` | non-negative integer | `0` |
| `--seed <u64>` | 64-bit integer | OS entropy |

### Behavior

- `--strategy canonical --noise 0` (defaults) → byte-identical to v0.1 output.
- `--strategy chain` → uses `encrypt_woven(..., noise=0, ...)` which delegates to `encrypt_chain` for canonical chain output.
- `--noise N` (with `N > 0`) → uses `encrypt_woven(..., noise=N, ...)` and implicitly forces chain mode (it makes no sense to mix noise with canonical adjacency).
- `--seed` only matters when an RNG is actually consumed (i.e. chain or noise). Documented as not-for-real-use.
- `decrypt` is unchanged: it already auto-detects `ext.plaintext_indices` and routes through the v0.2 path.

### Tests

- `round_trip_with_chain_strategy` — encrypt with `--strategy chain --seed 7`, decrypt round-trips.
- `round_trip_with_noise_injection` — encrypt with `--noise 5`, asserts `plaintext_indices` is in the JSON, decrypts to the original.
- `seeded_chain_encrypt_is_deterministic` — same seed → byte-identical stdout.

### README

Adds a quick-start example for both encoders and a row for the new flags.

## Test plan

- [x] CI passes (rustfmt / clippy / multi-OS test / wasm32 / rustdoc)
- [x] Existing CLI tests still green (no regression in default-path encrypt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
