### PR TITLE
feat(wasm): encryptWoven + WebUI 織りモード

### DIFF
--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -10,8 +10,9 @@
 
 #![doc(html_root_url = "https://docs.rs/musubi-wasm")]
 
-use musubi_core::{decrypt, encrypt, Alphabet, Ciphertext, Key};
+use musubi_core::{decrypt, encrypt, encrypt_woven, Alphabet, Ciphertext, Key};
 use rand::rngs::OsRng;
+use rand::SeedableRng;
 use wasm_bindgen::prelude::*;
 
 /// Crate version, baked in at compile time.
@@ -61,6 +62,48 @@ pub fn js_encrypt(
     }
     let pos = anchor.unwrap_or(n / 2);
     let cipher = encrypt(plaintext, &key, pos).map_err(to_js_error)?;
+    serde_json::to_string_pretty(&cipher).map_err(to_js_error)
+}
+
+/// Encrypt `plaintext` with the v0.2 woven encoder — a random spanning
+/// tree rooted at the anchor, optionally interleaved with `noise` dummy
+/// characters (迷い糸).
+///
+/// `noise = 0` produces a chain ciphertext (multi-knot encoder, 多重結び).
+/// `noise > 0` produces a noise-injected ciphertext that hides the true
+/// plaintext length from anyone without the key.
+///
+/// `seed` is optional. When provided, the chain/noise RNG is seeded for
+/// reproducible output (intended for tests/demos only). When omitted,
+/// the browser's `crypto.getRandomValues` (via [`OsRng`]) is used.
+///
+/// # Errors
+///
+/// Same as [`js_encrypt`].
+#[wasm_bindgen(js_name = encryptWoven)]
+pub fn js_encrypt_woven(
+    plaintext: &str,
+    key_json: &str,
+    anchor: Option<usize>,
+    noise: Option<usize>,
+    seed: Option<u64>,
+) -> Result<String, JsError> {
+    let alphabet = Alphabet::default_v1();
+    let key = Key::from_json(key_json, &alphabet).map_err(to_js_error)?;
+    let n = plaintext.chars().count();
+    if n == 0 {
+        return Err(JsError::new("plaintext is empty"));
+    }
+    let pos = anchor.unwrap_or(n / 2);
+    let noise = noise.unwrap_or(0);
+    let cipher = if let Some(s) = seed {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(s);
+        encrypt_woven(plaintext, &key, pos, noise, &mut rng)
+    } else {
+        let mut rng = OsRng;
+        encrypt_woven(plaintext, &key, pos, noise, &mut rng)
+    }
+    .map_err(to_js_error)?;
     serde_json::to_string_pretty(&cipher).map_err(to_js_error)
 }
 

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,12 @@
 // All cipher operations run locally in the browser via the
 // `musubi-wasm` crate; no network requests are made.
 
-import init, { keygen, encrypt, decrypt } from "./pkg/musubi_wasm.js";
+import init, {
+  keygen,
+  encrypt,
+  encryptWoven,
+  decrypt,
+} from "./pkg/musubi_wasm.js";
 
 await init();
 
@@ -99,9 +104,21 @@ document.getElementById("btn-encrypt").addEventListener("click", () => {
     }
     const anchorStr = document.getElementById("enc-anchor").value;
     const anchor = anchorStr === "" ? undefined : Number(anchorStr);
-    const cipher = encrypt(plain, key, anchor);
+    const noiseStr = document.getElementById("enc-noise").value;
+    const noise = noiseStr === "" ? 0 : Number(noiseStr);
+    const useChain = document.getElementById("enc-chain").checked;
+    const cipher =
+      useChain || noise > 0
+        ? encryptWoven(plain, key, anchor, noise, undefined)
+        : encrypt(plain, key, anchor);
     document.getElementById("enc-output").value = cipher;
-    setStatus("暗号化しました", "success");
+    if (noise > 0) {
+      setStatus(`暗号化しました（迷い糸 ${noise} 本）`, "success");
+    } else if (useChain) {
+      setStatus("暗号化しました（多重結び）", "success");
+    } else {
+      setStatus("暗号化しました", "success");
+    }
   } catch (e) {
     setStatus("暗号化に失敗: " + e.message, "error");
   }

--- a/web/index.html
+++ b/web/index.html
@@ -41,6 +41,21 @@
       <label for="enc-anchor" class="inline">アンカー位置 (省略時は中央)
         <input id="enc-anchor" type="number" min="0" placeholder="例: 2">
       </label>
+
+      <details class="weaving">
+        <summary>織りモード（v0.2）</summary>
+        <p class="lede">
+          v0.2 で導入された 2 つの追加エンコーダです。鍵がなければさらに解読しにくくなりますが、玩具暗号としての位置づけは変わりません。
+        </p>
+        <label class="inline">
+          <input id="enc-chain" type="checkbox">
+          多重結び — 関係をランダムな木の形に編む
+        </label>
+        <label for="enc-noise" class="inline">迷い糸の本数 (0 で無効)
+          <input id="enc-noise" type="number" min="0" value="0" placeholder="例: 5">
+        </label>
+      </details>
+
       <button id="btn-encrypt" class="primary">暗号化</button>
       <textarea id="enc-output" readonly placeholder="暗号文 (JSON)" rows="10"></textarea>
       <div class="actions">

--- a/web/style.css
+++ b/web/style.css
@@ -151,6 +151,27 @@ button.primary:hover { background: var(--accent); border-color: var(--accent); }
   margin-top: 0.5rem;
 }
 
+details.weaving {
+  margin: 1.2rem 0 0.4rem;
+  padding: 0.8rem 1rem;
+  border: 1px dashed var(--border);
+  border-radius: 4px;
+  background: #fdfdfa;
+}
+details.weaving > summary {
+  cursor: pointer;
+  color: var(--accent);
+  font-size: 0.9rem;
+  letter-spacing: 0.04em;
+}
+details.weaving[open] > summary {
+  margin-bottom: 0.6rem;
+}
+details.weaving .lede {
+  margin: 0 0 0.6rem;
+  font-size: 0.85rem;
+}
+
 #status {
   position: fixed;
   bottom: 1.2rem;


### PR DESCRIPTION
## Summary

PR #D of the [v0.2 ロードマップ](docs/PROPOSAL-v0.2.md). Wires the v0.2 encoders through the WASM façade and the browser UI.

### WASM

- New export: `encryptWoven(plaintext, keyJson, anchor?, noise?, seed?)` — calls `musubi_core::encrypt_woven`. `noise > 0` produces the noise-injected ciphertext; `noise = 0` reduces to the chain encoder. `seed` is optional; when omitted the browser's `crypto.getRandomValues` is used via `OsRng`.
- Existing `encrypt` and `decrypt` are untouched.
- `decrypt` already routes through the v0.2 path automatically when `ext.plaintext_indices` is present in the JSON.

### WebUI

- New collapsible **織りモード** panel under the encrypt form.
  - Checkbox: 多重結び (chain mode)
  - Number input: 迷い糸の本数 (noise count)
- `app.js` chooses the encoder:
  - `useChain || noise > 0` → `encryptWoven(...)`
  - otherwise → `encrypt(...)`
- Status ribbon reports which mode produced the ciphertext.
- Decrypt panel needs no UI change.

### Style

A small dashed-border `<details>` block keeps the weaving toggle visually subordinate to the primary form so the default UI stays approachable.

## Test plan

- [ ] CI passes (rustfmt / clippy / multi-OS test / wasm32 / rustdoc)
- [ ] `pages.yml` deploy succeeds and serves the new bundle
- [ ] Browser smoke test: chain mode + noise round-trip both succeed in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
