### PR TITLE
chore(release): v0.2.0 「織り (ori)」

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-04-28 — 「織り (ori)」
+
+The "weaving" release. Two backward-compatible encoder extensions
+introduce richer ciphertext shapes while keeping `version: 1` on disk.
+
+### Added
+- **多重結び (chain encoder)** — new `musubi_core::encrypt_chain(plaintext, key, anchor, rng)`. Produces a uniformly random spanning tree rooted at the anchor instead of the canonical 1-step adjacency graph. Decoder unchanged.
+- **迷い糸 (noise injection)** — new `musubi_core::encrypt_woven(plaintext, key, anchor, noise, rng)`. Interleaves `noise` dummy characters with the real plaintext, hiding the true plaintext length from anyone without the key.
+- **`Ciphertext::ext` / `CiphertextExt::plaintext_indices`** — optional v0.2 extension field. Omitted from JSON when absent, so noise-free ciphertexts stay v0.1-compatible.
+- **`musubi encrypt --strategy <canonical|chain>`** — pick the encoder.
+- **`musubi encrypt --noise <N>`** — inject `N` dummy characters.
+- **`musubi encrypt --seed <u64>`** — reproducible chain/noise RNG.
+- **`musubi-wasm`** export `encryptWoven(plaintext, keyJson, anchor?, noise?, seed?)`.
+- **WebUI 織りモード** — collapsible "advanced" panel with a 多重結び checkbox and 迷い糸の本数 input.
+- **Spec sections** — `docs/SPEC.md` §5.3 (`ext` field), §6.5 (chain encoder), §6.6 (woven encoder), §7.1 (decryption with `plaintext_indices`).
+
+### Changed
+- `musubi_core::decrypt` now auto-detects `ext.plaintext_indices` and re-assembles the plaintext in the recorded order. v0.1-shaped ciphertexts decode unchanged.
+
+### Compatibility
+- `FORMAT_VERSION` stays at `1`. v0.1 ciphertexts decode unchanged with v0.2.
+- v0.2 ciphertexts produced **without** `--noise` are byte-compatible with v0.1 decoders.
+- v0.2 ciphertexts produced **with** `--noise > 0` carry an `ext` field and require a v0.2 decoder.
+
 ## [0.1.0] — 2026-04-27
 
 First public release. The cipher, the CLI, and the browser UI all ship together.
@@ -27,5 +51,6 @@ First public release. The cipher, the CLI, and the browser UI all ship together.
 - `.github/workflows/pages.yml`: builds the WASM bundle with `wasm-pack` and deploys `web/` to GitHub Pages on every push to `main`.
 - CI's `wasm32 build` job now uses `wasm-pack` so PR validation matches the production deploy pipeline.
 
-[Unreleased]: https://github.com/masaki-09/musubi/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/masaki-09/musubi/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/masaki-09/musubi/releases/tag/v0.2.0
 [0.1.0]: https://github.com/masaki-09/musubi/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,14 +39,14 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "musubi-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "musubi-core",
 ]
 
 [[package]]
 name = "musubi-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "rand",
  "serde",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "musubi-wasm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "musubi-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,7 +15,7 @@ name = "musubi"
 path = "src/main.rs"
 
 [dependencies]
-musubi-core = { path = "../core", version = "0.1.0" }
+musubi-core = { path = "../core", version = "0.2.0" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 rand = "0.8"

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -14,7 +14,7 @@ readme = "../../README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-musubi-core = { path = "../core", version = "0.1.0" }
+musubi-core = { path = "../core", version = "0.2.0" }
 wasm-bindgen = "0.2"
 serde_json = "1"
 rand = "0.8"


### PR DESCRIPTION
## Summary

PR #E (final) of the [v0.2 ロードマップ](docs/PROPOSAL-v0.2.md). Marks the **v0.2.0「織り (ori)」** release.

### What's in v0.2.0

Two backward-compatible encoder extensions, surfaced in core / CLI / WASM / WebUI:

- **多重結び (chain encoder)** — `encrypt_chain()`, `--strategy chain`
- **迷い糸 (noise injection)** — `encrypt_woven()`, `--noise N`, `Ciphertext.ext.plaintext_indices`

`FORMAT_VERSION` stays at `1`. Noise-free v0.2 output is byte-compatible with v0.1 decoders.

### Bumps

- workspace `version` 0.1.0 → 0.2.0
- internal `musubi-core` dependency version in `cli` and `wasm` Cargo.toml
- Cargo.lock package versions

### CHANGELOG

`CHANGELOG.md` gains a `[0.2.0] — 2026-04-28 — 「織り (ori)」` section listing every Added / Changed item across the v0.2 PRs (#13, #14, #16, #17, #18) and a Compatibility note.

## Post-merge

After this lands on `main`:

1. `git tag v0.2.0 && git push origin v0.2.0`
2. `gh release create v0.2.0` with notes mirroring the CHANGELOG section
3. Verify Pages deploy serves the new bundle at <https://masaki-09.github.io/musubi/>

## Test plan

- [ ] CI passes
- [ ] After merge, tag pushes and the GitHub release is created
- [ ] WebUI shows the 織りモード panel after Pages deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
