### PR TITLE
feat(cli): スプラッシュ画面を追加（引数なし起動時）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,232 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "assert_cmd"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -15,9 +237,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -26,10 +308,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -41,7 +353,14 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 name = "musubi-cli"
 version = "0.2.0"
 dependencies = [
+ "anyhow",
+ "assert_cmd",
+ "clap",
  "musubi-core",
+ "predicates",
+ "rand",
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -58,8 +377,45 @@ dependencies = [
 name = "musubi-wasm"
 version = "0.2.0"
 dependencies = [
+ "getrandom 0.2.17",
  "musubi-core",
+ "rand",
+ "serde_json",
+ "wasm-bindgen",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "ppv-lite86"
@@ -68,6 +424,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -87,6 +483,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -115,8 +517,62 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -162,6 +618,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +639,25 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -199,10 +686,237 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "zerocopy"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -8,11 +8,15 @@
 //! All commands accept `-i/--input` for an input path (stdin if omitted)
 //! and `-o/--output` for an output path (stdout if omitted), so they
 //! compose naturally in shell pipelines.
+//!
+//! Invoked with no subcommand, prints a welcome splash screen (TTY only;
+//! plain-text fallback when piped).
 
 mod decrypt;
 mod encrypt;
 mod io;
 mod keygen;
+mod splash;
 
 use clap::{Parser, Subcommand};
 
@@ -23,7 +27,7 @@ use clap::{Parser, Subcommand};
 #[command(name = "musubi", version, about, long_about = None)]
 struct Cli {
     #[command(subcommand)]
-    command: Command,
+    command: Option<Command>,
 }
 
 #[derive(Subcommand)]
@@ -39,8 +43,12 @@ enum Command {
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     match cli.command {
-        Command::Keygen(args) => keygen::run(&args),
-        Command::Encrypt(args) => encrypt::run(&args),
-        Command::Decrypt(args) => decrypt::run(&args),
+        Some(Command::Keygen(args)) => keygen::run(&args),
+        Some(Command::Encrypt(args)) => encrypt::run(&args),
+        Some(Command::Decrypt(args)) => decrypt::run(&args),
+        None => {
+            splash::print();
+            Ok(())
+        }
     }
 }

--- a/crates/cli/src/splash.rs
+++ b/crates/cli/src/splash.rs
@@ -133,7 +133,7 @@ fn build_lines() -> Vec<String> {
 
     for (num, label, cmd) in steps {
         // step number + japanese label
-        let step_line = format!("  {}  {}", bright_red(num), dim(label),);
+        let step_line = format!("  {}  {}", bright_red(num), dim(label));
         let step_vis = 2 + 1 + 2 + label.chars().count();
         v.push(row(&step_line, step_vis));
 
@@ -151,7 +151,7 @@ fn build_lines() -> Vec<String> {
     // ── Links ─────────────────────────────────────────────────────────────────
     v.push(blank_row());
     {
-        let link_line = format!("  {}  {}", dim("Docs"), cyan("https://musubi.masak1.com"),);
+        let link_line = format!("  {}  {}", dim("Docs"), cyan("https://musubi.masak1.com"));
         v.push(row(&link_line, 2 + 4 + 2 + 25));
     }
     {

--- a/crates/cli/src/splash.rs
+++ b/crates/cli/src/splash.rs
@@ -1,0 +1,207 @@
+//! Splash screen shown when `musubi` is invoked with no subcommand.
+//!
+//! - If stdout is a TTY: full ANSI-coloured banner (Claude Code / Gemini CLI style).
+//! - If stdout is piped: plain-text fallback (no escape codes).
+
+use std::io::IsTerminal as _;
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+// ── ANSI helpers ──────────────────────────────────────────────────────────────
+
+macro_rules! c {
+    ($code:literal, $s:expr) => {
+        format!("\x1b[{}m{}\x1b[0m", $code, $s)
+    };
+}
+
+fn bold(s: &str) -> String      { c!("1",       s) }
+fn dim(s: &str) -> String       { c!("2",       s) }
+fn red(s: &str) -> String       { c!("31",      s) }
+fn bright_red(s: &str) -> String{ c!("91",      s) }
+fn white(s: &str) -> String     { c!("97",      s) }
+fn cyan(s: &str) -> String      { c!("36",      s) }
+fn yellow(s: &str) -> String    { c!("33",      s) }
+
+// ── Layout constant ───────────────────────────────────────────────────────────
+
+const W: usize = 58; // inner width (between borders)
+
+fn rule() -> String {
+    dim(&format!("╭{}╮", "─".repeat(W)))
+}
+fn rule_bottom() -> String {
+    dim(&format!("╰{}╯", "─".repeat(W)))
+}
+fn rule_mid() -> String {
+    dim(&format!("├{}┤", "─".repeat(W)))
+}
+
+/// Render one row: `│ <content padded to W-2> │`
+/// `content_len` is the *visible* length (without ANSI codes).
+fn row(content: &str, content_len: usize) -> String {
+    let pad = W.saturating_sub(2 + content_len); // 2 = leading space + trailing space
+    format!("{} {}{} {}", dim("│"), content, " ".repeat(pad), dim("│"))
+}
+
+fn blank_row() -> String {
+    row("", 0)
+}
+
+// ── Public entry point ────────────────────────────────────────────────────────
+
+pub fn print() {
+    if std::io::stdout().is_terminal() {
+        print_ansi();
+    } else {
+        print_plain();
+    }
+}
+
+// ── ANSI banner ───────────────────────────────────────────────────────────────
+
+fn print_ansi() {
+    let lines = build_lines();
+    for l in &lines {
+        println!("{l}");
+    }
+}
+
+fn build_lines() -> Vec<String> {
+    let mut v = Vec::new();
+
+    // ── Top border ────────────────────────────────────────────────────────────
+    v.push(rule());
+
+    // ── Title bar: "musubi 結び  v0.x.x" ──────────────────────────────────
+    v.push(blank_row());
+    {
+        // "  musubi" bold white + "  結び" bright red + "  v0.x.x" dim
+        let title = format!(
+            "{}  {}  {}",
+            bold(&white("musubi")),
+            bright_red("結び"),
+            dim(&format!("v{VERSION}"))
+        );
+        // visible: "  musubi  結び  v0.x.x"
+        // "musubi" = 6, "  " = 2, "結び" = 2 chars (4 cols wide), "  " = 2, "vX.Y.Z" depends
+        let vis = 6 + 2 + 4 + 2 + 1 + VERSION.len(); // 1 for 'v'
+        v.push(row(&title, vis));
+    }
+    {
+        let tagline = dim("関係性暗号 — Relational classical cipher");
+        // "関係性暗号" = 5 chars × 2 = 10 cols, " — Relational classical cipher" = 30
+        let vis = 10 + 3 + 29; // "—" is 3 bytes but 1 col, space around = 3 cols total
+        v.push(row(&tagline, vis));
+    }
+    v.push(blank_row());
+
+    // ── Divider ───────────────────────────────────────────────────────────────
+    v.push(rule_mid());
+
+    // ── Quick start ───────────────────────────────────────────────────────────
+    v.push(blank_row());
+    {
+        let label = format!("{}  Quick start", bold(&cyan("◆")));
+        v.push(row(&label, 2 + 11)); // "◆" 1 col + "  Quick start" 13 = 14 ... tweak
+    }
+    v.push(blank_row());
+
+    let steps: &[(&str, &str, &str)] = &[
+        ("①", "鍵を生成", "musubi keygen -o my.key"),
+        ("②", "暗号化  ", "musubi encrypt -k my.key -i plain.txt -o cipher.json"),
+        ("③", "復号    ", "musubi decrypt -k my.key -i cipher.json"),
+    ];
+
+    for (num, label, cmd) in steps {
+        // step number + japanese label
+        let step_line = format!(
+            "  {}  {}",
+            bright_red(num),
+            dim(label),
+        );
+        let step_vis = 2 + 1 + 2 + label.chars().count();
+        v.push(row(&step_line, step_vis));
+
+        // command (indented)
+        let cmd_line = format!("     {}", red(cmd));
+        let cmd_vis = 5 + cmd.len();
+        v.push(row(&cmd_line, cmd_vis));
+
+        v.push(blank_row());
+    }
+
+    // ── Divider ───────────────────────────────────────────────────────────────
+    v.push(rule_mid());
+
+    // ── Links ─────────────────────────────────────────────────────────────────
+    v.push(blank_row());
+    {
+        let link_line = format!(
+            "  {}  {}",
+            dim("Docs"),
+            cyan("https://musubi.masak1.com"),
+        );
+        v.push(row(&link_line, 2 + 4 + 2 + 25));
+    }
+    {
+        let link_line = format!(
+            "  {}  {}",
+            dim("Src "),
+            cyan("https://github.com/masaki-09/musubi"),
+        );
+        v.push(row(&link_line, 2 + 4 + 2 + 35));
+    }
+    v.push(blank_row());
+
+    // ── Divider ───────────────────────────────────────────────────────────────
+    v.push(rule_mid());
+
+    // ── Disclaimer ────────────────────────────────────────────────────────────
+    v.push(blank_row());
+    {
+        let warn_line = format!(
+            "  {}  {}",
+            yellow("⚠"),
+            dim("玩具暗号です。機密情報の保護には使用しないでください。"),
+        );
+        // visible: "  ⚠  玩具暗号です。機密情報の保護には使用しないでください。"
+        // "⚠" = 1, "  " = 2, space before = 2, text = 26 chars × 2 + 4 punct ≈ 52
+        let vis = 2 + 1 + 2 + 52;
+        v.push(row(&warn_line, vis));
+    }
+    v.push(blank_row());
+
+    // ── Bottom border ─────────────────────────────────────────────────────────
+    v.push(rule_bottom());
+
+    // ── Tip after box ─────────────────────────────────────────────────────────
+    v.push(String::new());
+    v.push(format!(
+        "  {} {}",
+        dim("サブコマンドのヘルプ:"),
+        white("musubi <SUBCOMMAND> --help"),
+    ));
+    v.push(String::new());
+
+    v
+}
+
+// ── Plain-text fallback ───────────────────────────────────────────────────────
+
+fn print_plain() {
+    println!("musubi (結び) v{VERSION}");
+    println!("関係性暗号 — Relational classical cipher");
+    println!();
+    println!("Quick start:");
+    println!("  1. musubi keygen -o my.key");
+    println!("  2. musubi encrypt -k my.key -i plain.txt -o cipher.json");
+    println!("  3. musubi decrypt -k my.key -i cipher.json");
+    println!();
+    println!("Docs:   https://musubi.masak1.com");
+    println!("Source: https://github.com/masaki-09/musubi");
+    println!();
+    println!("WARNING: 玩具暗号 (toy cipher). Do NOT use for sensitive data.");
+    println!();
+    println!("Usage: musubi <SUBCOMMAND> --help");
+}

--- a/crates/cli/src/splash.rs
+++ b/crates/cli/src/splash.rs
@@ -15,13 +15,27 @@ macro_rules! c {
     };
 }
 
-fn bold(s: &str) -> String      { c!("1",       s) }
-fn dim(s: &str) -> String       { c!("2",       s) }
-fn red(s: &str) -> String       { c!("31",      s) }
-fn bright_red(s: &str) -> String{ c!("91",      s) }
-fn white(s: &str) -> String     { c!("97",      s) }
-fn cyan(s: &str) -> String      { c!("36",      s) }
-fn yellow(s: &str) -> String    { c!("33",      s) }
+fn bold(s: &str) -> String {
+    c!("1", s)
+}
+fn dim(s: &str) -> String {
+    c!("2", s)
+}
+fn red(s: &str) -> String {
+    c!("31", s)
+}
+fn bright_red(s: &str) -> String {
+    c!("91", s)
+}
+fn white(s: &str) -> String {
+    c!("97", s)
+}
+fn cyan(s: &str) -> String {
+    c!("36", s)
+}
+fn yellow(s: &str) -> String {
+    c!("33", s)
+}
 
 // ── Layout constant ───────────────────────────────────────────────────────────
 
@@ -109,17 +123,17 @@ fn build_lines() -> Vec<String> {
 
     let steps: &[(&str, &str, &str)] = &[
         ("①", "鍵を生成", "musubi keygen -o my.key"),
-        ("②", "暗号化  ", "musubi encrypt -k my.key -i plain.txt -o cipher.json"),
+        (
+            "②",
+            "暗号化  ",
+            "musubi encrypt -k my.key -i plain.txt -o cipher.json",
+        ),
         ("③", "復号    ", "musubi decrypt -k my.key -i cipher.json"),
     ];
 
     for (num, label, cmd) in steps {
         // step number + japanese label
-        let step_line = format!(
-            "  {}  {}",
-            bright_red(num),
-            dim(label),
-        );
+        let step_line = format!("  {}  {}", bright_red(num), dim(label),);
         let step_vis = 2 + 1 + 2 + label.chars().count();
         v.push(row(&step_line, step_vis));
 
@@ -137,11 +151,7 @@ fn build_lines() -> Vec<String> {
     // ── Links ─────────────────────────────────────────────────────────────────
     v.push(blank_row());
     {
-        let link_line = format!(
-            "  {}  {}",
-            dim("Docs"),
-            cyan("https://musubi.masak1.com"),
-        );
+        let link_line = format!("  {}  {}", dim("Docs"), cyan("https://musubi.masak1.com"),);
         v.push(row(&link_line, 2 + 4 + 2 + 25));
     }
     {


### PR DESCRIPTION
## Summary

- `musubi` をサブコマンドなしで実行すると、Gemini CLI / Claude Code 風の ANSI カラーバナーを表示
- TTY 判定（`std::io::IsTerminal`、MSRV 1.75 ✓）により、パイプ・リダイレクト時はプレーンテキストへ自動フォールバック
- 既存サブコマンドの動作・テストに変更なし（全 9 テスト通過、clippy clean）

## 変更点

| ファイル | 内容 |
|---|---|
| `crates/cli/src/main.rs` | `Command` → `Option<Command>`、`None` → `splash::print()` |
| `crates/cli/src/splash.rs` | ANSI ボーダー・クイックスタート・リンク・免責バナー |

## スプラッシュ画面（TTY 時）

```
╭──────────────────────────────────────────────────────────╮
│                                                          │
│  musubi  結び  v0.2.0                                    │
│  関係性暗号 — Relational classical cipher                 │
│                                                          │
├──────────────────────────────────────────────────────────┤
│                                                          │
│  ◆  Quick start                                          │
│                                                          │
│  ①  鍵を生成                                             │
│     musubi keygen -o my.key                              │
│                                                          │
│  ②  暗号化                                               │
│     musubi encrypt -k my.key -i plain.txt -o cipher.json │
│                                                          │
│  ③  復号                                                 │
│     musubi decrypt -k my.key -i cipher.json              │
│                                                          │
├──────────────────────────────────────────────────────────┤
│                                                          │
│  Docs  https://musubi.masak1.com                         │
│  Src   https://github.com/masaki-09/musubi               │
│                                                          │
├──────────────────────────────────────────────────────────┤
│                                                          │
│  ⚠  玩具暗号です。機密情報の保護には使用しないでください。  │
│                                                          │
╰──────────────────────────────────────────────────────────╯

  サブコマンドのヘルプ: musubi <SUBCOMMAND> --help
```

## Test plan

- [x] `cargo build -p musubi-cli` — コンパイル成功
- [x] `cargo test -p musubi-cli` — 9/9 通過
- [x] `cargo clippy -p musubi-cli -- -D warnings` — 警告なし
- [ ] 実ターミナルで `musubi`（ANSI カラー確認）
- [ ] パイプで `musubi | cat`（プレーンテキスト確認）
- [ ] `musubi --help` が従来どおり動くこと
