### PR TITLE
chore(core): add bench_decrypt example for O(n^2) investigation

### DIFF
--- a/crates/core/examples/bench_decrypt.rs
+++ b/crates/core/examples/bench_decrypt.rs
@@ -2,10 +2,10 @@
 //! lengths and both encoder strategies.
 //!
 //! Run with:
-//!     cargo run --release --example bench_decrypt
+//!     cargo run --release --example `bench_decrypt`
 //!
-//! Output is CSV on stdout (n, strategy, encrypt_ms, decrypt_ms) so it can
-//! be piped into a plot or table.
+//! Output is CSV on stdout (`n`, strategy, `encrypt_ms`, `decrypt_ms`) so
+//! it can be piped into a plot or table.
 
 use std::time::Instant;
 

--- a/crates/core/examples/bench_decrypt.rs
+++ b/crates/core/examples/bench_decrypt.rs
@@ -1,0 +1,80 @@
+//! Quick wall-clock benchmark for `decrypt` across a sweep of plaintext
+//! lengths and both encoder strategies.
+//!
+//! Run with:
+//!     cargo run --release --example bench_decrypt
+//!
+//! Output is CSV on stdout (n, strategy, encrypt_ms, decrypt_ms) so it can
+//! be piped into a plot or table.
+
+use std::time::Instant;
+
+use musubi_core::{decrypt, encrypt, encrypt_chain, Alphabet, Key};
+use rand::rngs::StdRng;
+use rand::seq::SliceRandom;
+use rand::SeedableRng;
+
+const SIZES: &[usize] = &[500, 1_000, 2_000, 4_000, 8_000, 16_000, 32_000];
+const REPEATS: usize = 5;
+
+fn random_plaintext(alphabet: &Alphabet, n: usize, rng: &mut StdRng) -> String {
+    // Build a uniformly random plaintext drawn from the alphabet itself,
+    // so we never trip CharOutsideAlphabet.
+    let chars: &[char] = alphabet.chars();
+    (0..n)
+        .map(|_| *chars.choose(rng).expect("alphabet non-empty"))
+        .collect()
+}
+
+fn main() {
+    let alphabet = Alphabet::default_v1();
+    let mut rng = StdRng::seed_from_u64(0xBEEF_CAFE);
+    let key = Key::random(&alphabet, &mut rng);
+
+    println!("n,strategy,encrypt_ms,decrypt_ms");
+
+    for &n in SIZES {
+        let plaintext = random_plaintext(&alphabet, n, &mut rng);
+
+        // ── canonical strategy (v0.1 default, adjacent references) ───────
+        let mut enc_ms = 0.0;
+        let mut dec_ms = 0.0;
+        for _ in 0..REPEATS {
+            let t0 = Instant::now();
+            let cipher = encrypt(&plaintext, &key, n / 2).unwrap();
+            enc_ms += t0.elapsed().as_secs_f64() * 1000.0;
+
+            let t1 = Instant::now();
+            let recovered = decrypt(&cipher, &key).unwrap();
+            dec_ms += t1.elapsed().as_secs_f64() * 1000.0;
+
+            assert_eq!(recovered.chars().count(), n);
+        }
+        println!(
+            "{n},canonical,{:.3},{:.3}",
+            enc_ms / REPEATS as f64,
+            dec_ms / REPEATS as f64
+        );
+
+        // ── chain strategy (v0.2 random spanning tree) ───────────────────
+        let mut enc_ms = 0.0;
+        let mut dec_ms = 0.0;
+        for _ in 0..REPEATS {
+            let mut rng = StdRng::seed_from_u64(7);
+            let t0 = Instant::now();
+            let cipher = encrypt_chain(&plaintext, &key, n / 2, &mut rng).unwrap();
+            enc_ms += t0.elapsed().as_secs_f64() * 1000.0;
+
+            let t1 = Instant::now();
+            let recovered = decrypt(&cipher, &key).unwrap();
+            dec_ms += t1.elapsed().as_secs_f64() * 1000.0;
+
+            assert_eq!(recovered.chars().count(), n);
+        }
+        println!(
+            "{n},chain,{:.3},{:.3}",
+            enc_ms / REPEATS as f64,
+            dec_ms / REPEATS as f64
+        );
+    }
+}


### PR DESCRIPTION
## Context

External report claims decrypt is O(n^2) in the default `canonical` strategy:

> expected: O(N) like encrypt
> actual: 26 ms at n=5,000, doubling input quadruples decrypt time
> commit 560d375, rustc 1.92, macOS 14.6 ARM64

This PR adds a reproducible benchmark so anyone can verify on their own hardware.

## What

`crates/core/examples/bench_decrypt.rs` — wall-clock CSV bench across n = 500..32,000 for both `canonical` and `chain` encoders. Five-run average per cell, fixed seed, anchor at n/2.

```
cargo run --release --example bench_decrypt -p musubi-core
```

## Findings

| n | canonical (ms) | x | chain (ms) | x |
|---:|---:|---:|---:|---:|
| 500 | 0.086 | — | 0.011 | — |
| 1,000 | 0.494 | 5.7x | 0.021 | 1.9x |
| 2,000 | 1.299 | 2.6x | 0.059 | 2.8x |
| 4,000 | 5.159 | 4.0x | 0.135 | 2.3x |
| 8,000 | 20.066 | 3.9x | 0.267 | 2.0x |
| 16,000 | 72.480 | 3.6x | 0.531 | 2.0x |
| 32,000 | 295.843 | 4.1x | 1.141 | 2.1x |

- canonical: ~n^1.85 (textbook quadratic, doubling -> 4x)
- chain: ~n^1.16 (effectively linear)

Confirms the report. Root cause and fix plan live at musubi.masak1.com/perf/decrypt-quadratic — the actual O(n) BFS fix will land in a follow-up PR.

## Test plan

- [x] `cargo build --release --example bench_decrypt -p musubi-core`
- [x] `cargo run --release --example bench_decrypt -p musubi-core` (CSV output, 5-run averages)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] CI green