### PR TITLE
fix(core): make decrypt linear-time via BFS from anchor

### DIFF
--- a/crates/core/src/cipher.rs
+++ b/crates/core/src/cipher.rs
@@ -1,5 +1,7 @@
 //! `encrypt` / `decrypt` and the [`Ciphertext`] container.
 
+use std::collections::VecDeque;
+
 use rand::seq::SliceRandom;
 use rand::Rng;
 use rand::RngCore;
@@ -378,40 +380,56 @@ pub fn decrypt(cipher: &Ciphertext, key: &Key) -> Result<String> {
 
     let mut chars: Vec<Option<char>> = vec![None; n];
     chars[anchor_pos] = Some(cipher.anchor.character);
-    let mut remaining = n - 1;
 
-    while remaining > 0 {
-        let mut progress = false;
-        for i in 0..n {
-            if chars[i].is_some() {
-                continue;
-            }
-            let rel =
-                cipher.relations[i]
-                    .as_ref()
-                    .ok_or_else(|| MusubiError::MalformedCiphertext {
-                        reason: format!("missing relation at position {i}"),
-                    })?;
-            let ref_idx = rel.reference();
-            if ref_idx >= n {
-                return Err(MusubiError::MalformedCiphertext {
-                    reason: format!(
-                        "relation at position {i} references out-of-range index {ref_idx}"
-                    ),
-                });
-            }
-            let Some(ref_char) = chars[ref_idx] else {
-                continue;
-            };
-            chars[i] = Some(apply_relation(*rel, ref_char, key)?);
-            progress = true;
-            remaining -= 1;
+    // Build a child-list index in O(n). Each non-anchor position has
+    // exactly one relation pointing at its parent; we invert that to a
+    // map from parent to children so the resolve pass below can run in
+    // BFS order. This pass also validates relation presence and
+    // reference range for *every* slot up-front.
+    let mut children: Vec<Vec<usize>> = vec![Vec::new(); n];
+    for (i, rel) in cipher.relations.iter().enumerate() {
+        if i == anchor_pos {
+            continue;
         }
-        if !progress {
+        let rel = rel
+            .as_ref()
+            .ok_or_else(|| MusubiError::MalformedCiphertext {
+                reason: format!("missing relation at position {i}"),
+            })?;
+        let ref_idx = rel.reference();
+        if ref_idx >= n {
             return Err(MusubiError::MalformedCiphertext {
-                reason: "relation graph has cycles or unreachable positions".to_string(),
+                reason: format!("relation at position {i} references out-of-range index {ref_idx}"),
             });
         }
+        children[ref_idx].push(i);
+    }
+
+    // BFS from the anchor along reverse-reference edges and resolve
+    // each child as soon as its parent is reached. The reference graph
+    // is a forest with the anchor as the root of one tree (each
+    // non-anchor has exactly one parent), so visiting in BFS order
+    // guarantees the parent's character is already known when we
+    // touch a child — a single linear pass suffices.
+    let mut queue: VecDeque<usize> = VecDeque::with_capacity(n);
+    queue.push_back(anchor_pos);
+    let mut visited: usize = 1;
+    while let Some(p) = queue.pop_front() {
+        for &c in &children[p] {
+            let rel = cipher.relations[c]
+                .as_ref()
+                .expect("validated when building children");
+            let ref_char = chars[p].expect("BFS visits a parent before its child");
+            chars[c] = Some(apply_relation(*rel, ref_char, key)?);
+            queue.push_back(c);
+            visited += 1;
+        }
+    }
+
+    if visited != n {
+        return Err(MusubiError::MalformedCiphertext {
+            reason: "relation graph has cycles or unreachable positions".to_string(),
+        });
     }
 
     if let Some(ext) = &cipher.ext {


### PR DESCRIPTION
## Summary

Replaces the O(n^2) fix-point loop in \`decrypt\` with a single BFS from the anchor. Closes the externally-reported quadratic decrypt issue investigated at <https://musubi.masak1.com/perf/decrypt-quadratic>.

## Problem

The previous loop scanned all \`n\` unresolved positions per pass and only resolved positions whose parent was already known:

\`\`\`rust
while remaining > 0 {
    for i in 0..n { /* resolve i if its parent is known, else skip */ }
}
\`\`\`

For the default \`canonical\` encoder (adjacent-chain reference graph), only the *immediate neighbour* of an already-resolved node could be filled per pass on the side that scans away from the anchor. With the central-anchor default, this took \`n/2\` passes -> O(n^2).

Reproducible bench: \`cargo run --release --example bench_decrypt -p musubi-core\`.

## Fix

The reference graph is a forest where every non-anchor position has exactly one parent (its \`rel.reference()\`), and the anchor is the root of one tree. BFS from the anchor visits every parent before its children, so each position is resolved in a single pass.

Three steps:

1. **Build child-list index** in O(n). Validates relation presence and reference range up-front.
2. **BFS from anchor**, resolving each child the moment it is dequeued.
3. **Cycle/unreachable check** via \`visited != n\` after the queue drains — same error class (\`MalformedCiphertext\`) as before.

## Measurements (Windows, rustc 1.92, --release, 5-run avg)

### canonical (the regression's victim)

| n | before | after | speedup |
|---:|---:|---:|---:|
| 500 | 0.086 ms | 0.035 ms | 2.5x |
| 1,000 | 0.494 ms | 0.083 ms | 6.0x |
| 2,000 | 1.299 ms | 0.177 ms | 7.3x |
| 4,000 | 5.159 ms | 0.318 ms | 16.2x |
| 8,000 | 20.066 ms | 0.569 ms | 35.3x |
| 16,000 | 72.480 ms | 1.152 ms | **63x** |
| 32,000 | 295.843 ms | 2.385 ms | **124x** |

### chain (already linear; bookkeeping cost only)

| n | before | after |
|---:|---:|---:|
| 32,000 | 1.141 ms | 2.256 ms |

Slight slowdown (~2x) for chain due to the explicit \`children\` Vec allocation that BFS needs. Acceptable: chain is no longer doing better than O(n) by accident; both modes are now bounded by the same algorithm.

### Doubling ratios (after)

| n / 2n | canonical | chain |
|---:|---:|---:|
| 500 -> 1,000 | 2.4x | 4.7x |
| 1k -> 2k | 2.1x | 1.5x |
| 2k -> 4k | 1.8x | 2.5x |
| 4k -> 8k | 1.8x | 1.7x |
| 8k -> 16k | 2.0x | 1.7x |
| 16k -> 32k | 2.1x | 2.2x |

Both at ~2.0x per doubling — true linear time.

## Compatibility

- **On-disk format**: unchanged. Existing v0.1 / v0.2 ciphertexts decode bit-identically.
- **Error class**: same (\`MalformedCiphertext\`). Some error *messages* are tighter (we now report \"missing relation at position X\" eagerly instead of falling back to \"cycles or unreachable\"), but no test asserts on message content.
- **MSRV**: unchanged (1.75). \`std::collections::VecDeque\` only.

## Test plan

- [x] \`cargo test --workspace\` (36 core + 9 CLI + 6 vectors + doctest = all pass)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` (clean)
- [x] \`cargo fmt --all -- --check\` (clean)
- [x] \`cargo run --release --example bench_decrypt\` (numbers above)
- [x] CI green