### PR TITLE
chore(release): v0.2.1 「整え (totonoe)」

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] — 2026-04-29 — 「整え (totonoe)」
+
+A maintenance release. The cipher gets faster, the CLI gets a face,
+and the docs gain a postmortem of how we got here.
+
+### Fixed
+- **`musubi_core::decrypt` is now linear time** — replaces the O(n²) fix-point loop with a single BFS from the anchor over a precomputed reference graph. Same on-disk format, same `MalformedCiphertext` error class, identical output. n=32,000 falls from 295.843 ms to 2.385 ms (124× speedup); doubling ratios sit at ~2.0× across the board. (#22)
+
+### Added
+- **CLI splash screen** — running `musubi` without a subcommand now prints a Gemini CLI / Claude Code-style banner with quick-start steps, doc links, and a toy-cipher disclaimer. TTY-aware: pipes and redirects fall back to plain text via `std::io::IsTerminal`. (#20)
+- **`crates/core/examples/bench_decrypt`** — reproducible CSV benchmark of `decrypt` across n = 500..32,000 for both encoder strategies. Run with `cargo run --release --example bench_decrypt -p musubi-core`. (#21)
+
+### Compatibility
+- `FORMAT_VERSION` stays at `1`. v0.1 and v0.2.0 ciphertexts decode bit-identically with v0.2.1.
+- MSRV stays at Rust 1.75.
+
 ## [0.2.0] — 2026-04-28 — 「織り (ori)」
 
 The "weaving" release. Two backward-compatible encoder extensions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "musubi-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "musubi-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "rand",
  "serde",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "musubi-wasm"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "getrandom 0.2.17",
  "musubi-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"


### PR DESCRIPTION
## Summary

Maintenance release rolling up three changes since v0.2.0.

## What's in 0.2.1

### Fixed
- **`musubi_core::decrypt` is now linear time** (#22) — replaces the O(n²) fix-point loop with a single BFS from the anchor over a precomputed reference graph. n=32,000 falls from 295.843 ms to 2.385 ms (**124× speedup**); doubling ratios sit at ~2.0× across the board. Investigated at <https://musubi.masak1.com/perf/decrypt-quadratic>.

### Added
- **CLI splash screen** (#20) — running \`musubi\` without a subcommand prints a Gemini CLI / Claude Code-style banner with quick-start steps, doc links, and a toy-cipher disclaimer. TTY-aware fallback to plain text via \`std::io::IsTerminal\`.
- **\`crates/core/examples/bench_decrypt\`** (#21) — reproducible CSV benchmark of \`decrypt\` across n = 500..32,000 for both encoder strategies.

## Compatibility

- \`FORMAT_VERSION\` stays at \`1\`. v0.1 and v0.2.0 ciphertexts decode bit-identically with v0.2.1.
- MSRV stays at Rust 1.75.

## Release plan

1. Merge this PR to \`main\`.
2. Tag \`v0.2.1\` on the merge commit and push.
3. Create the GitHub Release from CHANGELOG.

## Test plan

- [x] \`cargo build --workspace\` (musubi-core / musubi-cli / musubi-wasm all compile at 0.2.1)
- [x] \`cargo test --workspace\` (51 tests pass on the merged main)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` (clean)
- [x] \`cargo fmt --all -- --check\` (clean)
- [ ] CI green