### PR TITLE
docs: define maintenance-release codename convention (整え vol.N)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ Thumbs.db
 
 # Logs
 *.log
+
+# AI context snapshot (intentionally local-only — for future AI agents
+# to bootstrap from a clean context. See AI_CONTEXT.md §0.2.)
+AI_CONTEXT.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,16 @@ All notable changes to **musubi** are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Codename convention
+
+Each release carries a poetic codename in the spirit of "結び (musubi)":
+
+- **Feature releases** get a unique codename. Examples: `0.1.0` 「初結び (hatsu-musubi)」, `0.2.0` 「織り (ori)」.
+- **Maintenance releases** (patches, performance fixes, polish) all share the codename **「整え (totonoe)」** and are numbered sequentially as `vol.N`. Examples: `0.2.1` is 「整え vol.1」, the next maintenance release will be 「整え vol.2」, and so on. The numbering is independent of the SemVer patch version — it counts maintenance releases since project start.
+
 ## [Unreleased]
 
-## [0.2.1] — 2026-04-29 — 「整え (totonoe)」
+## [0.2.1] — 2026-04-29 — 「整え vol.1 (totonoe vol.1)」
 
 A maintenance release. The cipher gets faster, the CLI gets a face,
 and the docs gain a postmortem of how we got here.


### PR DESCRIPTION
## Summary

Establishes a permanent naming convention for releases:

- **Feature releases** (e.g. \`0.1.0\`, \`0.2.0\`) keep unique poetic codenames: 初結び, 織り, …
- **Maintenance releases** (patches, perf fixes, polish) all share the codename **「整え (totonoe)」** and are numbered as \`vol.N\` regardless of SemVer patch version.

Retroactively names \`0.2.1\` as **「整え vol.1」** — the first totonoe.

## What changes

- \`CHANGELOG.md\`: adds a 「Codename convention」 section at the top documenting the rule. Renames the \`0.2.1\` heading to 「整え vol.1 (totonoe vol.1)」.
- \`.gitignore\`: adds \`AI_CONTEXT.md\` (a local-only AI bootstrapping snapshot, intentionally never tracked).

## Future application

Next maintenance release will be 「整え vol.2」, then 「整え vol.3」, etc. The vol counter is independent of SemVer (could be \`0.2.5\` 「整え vol.4」 if vol.2/3 happened to be 0.2.2 and 0.2.3).

The companion homepage PR (masaki-09/My-Portfolio) wires this into \`/releases\` UI with a maintenance badge.

## Test plan

- [x] CHANGELOG renders correctly when scrolled
- [x] No code change in crates → existing tests unaffected
- [ ] CI green